### PR TITLE
Add TronGrid fallback support and watched TRC20 token syncing

### DIFF
--- a/Sources/TronKit/Core/AccountInfoManager.swift
+++ b/Sources/TronKit/Core/AccountInfoManager.swift
@@ -4,6 +4,7 @@ import HsExtensions
 
 class AccountInfoManager {
     private let storage: AccountInfoStorage
+    private var watchedTokens = Set<Address>()
 
     init(storage: AccountInfoStorage) {
         self.storage = storage
@@ -11,7 +12,6 @@ class AccountInfoManager {
 
     private let trxBalanceSubject = PassthroughSubject<BigUInt, Never>()
     private let trc20BalanceSubject = PassthroughSubject<(Address, BigUInt), Never>()
-
     private let accountActiveSubject = PassthroughSubject<Bool, Never>()
 
     var trxBalance: BigUInt {
@@ -42,6 +42,7 @@ extension AccountInfoManager {
         accountActiveSubject.eraseToAnyPublisher()
     }
 
+    // Full sync via history provider: replaces all TRC20 balances at once
     func handle(accountInfoResponse: AccountInfoResponse) {
         accountActive = true
         let trxBalance = BigUInt(accountInfoResponse.balance)
@@ -53,6 +54,29 @@ extension AccountInfoManager {
             storage.save(trc20Balance: value, address: address.base58)
             trc20BalanceSubject.send((address, value))
         }
+    }
+
+    // RPC sync: updates TRX balance only, does not touch TRC20 balances
+    func handle(trxBalance: BigUInt) {
+        accountActive = true
+        storage.save(trxBalance: trxBalance)
+        trxBalanceSubject.send(trxBalance)
+    }
+
+    // RPC sync: updates a single TRC20 balance without clearing others
+    func handle(trc20Balance: BigUInt, contractAddress: Address) {
+        storage.save(trc20Balance: trc20Balance, address: contractAddress.base58)
+        trc20BalanceSubject.send((contractAddress, trc20Balance))
+    }
+
+    func watchTrc20(contractAddress: Address) {
+        watchedTokens.insert(contractAddress)
+    }
+
+    // All addresses to sync balances for: previously seen (non-zero) + manually watched
+    func trc20AddressesToSync() -> [Address] {
+        let known = Set(storage.allTrc20Addresses().compactMap { try? Address(address: $0) })
+        return Array(known.union(watchedTokens))
     }
 
     func handleInactiveAccount() {

--- a/Sources/TronKit/Core/AllowanceManager.swift
+++ b/Sources/TronKit/Core/AllowanceManager.swift
@@ -8,11 +8,11 @@ enum AllowanceParsingError: Error {
 }
 
 class AllowanceManager {
-    private let tronGridProvider: TronGridProvider
+    private let rpcApiProvider: IRpcApiProvider
     private let address: Address
 
-    init(tronGridProvider: TronGridProvider, address: Address) {
-        self.tronGridProvider = tronGridProvider
+    init(rpcApiProvider: IRpcApiProvider, address: Address) {
+        self.rpcApiProvider = rpcApiProvider
         self.address = address
     }
 
@@ -20,7 +20,7 @@ class AllowanceManager {
         let methodData = AllowanceMethod(owner: address, spender: spenderAddress).encodedABI()
 
         let callJsonRpc = CallJsonRpc(contractAddress: contractAddress, data: methodData)
-        let response: Data = try await tronGridProvider.fetch(rpc: callJsonRpc)
+        let response: Data = try await rpcApiProvider.fetch(rpc: callJsonRpc)
         guard response.count >= 32 else {
             throw AllowanceParsingError.illegalResponse
         }

--- a/Sources/TronKit/Core/ChainParameterManager.swift
+++ b/Sources/TronKit/Core/ChainParameterManager.swift
@@ -1,9 +1,9 @@
 class ChainParameterManager {
-    private let tronGridProvider: TronGridProvider
+    private let nodeApiProvider: INodeApiProvider
     private let storage: SyncerStorage
 
-    init(tronGridProvider: TronGridProvider, storage: SyncerStorage) {
-        self.tronGridProvider = tronGridProvider
+    init(nodeApiProvider: INodeApiProvider, storage: SyncerStorage) {
+        self.nodeApiProvider = nodeApiProvider
         self.storage = storage
     }
 }
@@ -26,7 +26,7 @@ extension ChainParameterManager {
     }
 
     func sync() async throws {
-        let parameters = try await tronGridProvider.fetchChainParameters()
+        let parameters = try await nodeApiProvider.fetchChainParameters()
         for parameter in parameters {
             storage.saveChainParameter(key: parameter.key, value: parameter.value)
         }

--- a/Sources/TronKit/Core/FeeProvider.swift
+++ b/Sources/TronKit/Core/FeeProvider.swift
@@ -3,11 +3,13 @@ import Foundation
 import SwiftProtobuf
 
 class FeeProvider {
-    private let tronGridProvider: TronGridProvider
+    private let rpcApiProvider: IRpcApiProvider
+    private let nodeApiProvider: INodeApiProvider
     private let chainParameterManager: ChainParameterManager
 
-    init(tronGridProvider: TronGridProvider, chainParameterManager: ChainParameterManager) {
-        self.tronGridProvider = tronGridProvider
+    init(rpcApiProvider: IRpcApiProvider, nodeApiProvider: INodeApiProvider, chainParameterManager: ChainParameterManager) {
+        self.rpcApiProvider = rpcApiProvider
+        self.nodeApiProvider = nodeApiProvider
         self.chainParameterManager = chainParameterManager
     }
 
@@ -19,16 +21,7 @@ class FeeProvider {
     }
 
     func isAccountActive(address: Address) async throws -> Bool {
-        do {
-            _ = try await tronGridProvider.fetchAccountInfo(address: address.base58)
-            return true
-        } catch let error as TronGridProvider.RequestError {
-            guard case .failedToFetchAccountInfo = error else {
-                throw error
-            }
-
-            return false
-        }
+        return try await nodeApiProvider.fetchAccount(address: address.base58) != nil
     }
 }
 
@@ -50,7 +43,7 @@ extension FeeProvider {
 
         case let contract as TriggerSmartContract:
             let energyPrice = chainParameterManager.energyFee
-            let energyRequired = try await tronGridProvider.fetch(
+            let energyRequired = try await rpcApiProvider.fetch(
                 rpc: EstimateGasJsonRpc(
                     from: contract.ownerAddress,
                     to: contract.contractAddress,
@@ -87,7 +80,7 @@ extension FeeProvider {
         transaction.rawData = rawData
         transaction.signature = [Data(repeating: 0, count: 65)]
 
-        let bandwidthPoints = try transaction.serializedData().count + 64 // transaction + 64 (maximum ret size)
+        let bandwidthPoints = try transaction.serializedData().count + 64
         let bandwidthPointPrice = chainParameterManager.transactionFee
         fees.append(.bandwidth(points: bandwidthPoints, price: bandwidthPointPrice))
 

--- a/Sources/TronKit/Core/Kit.swift
+++ b/Sources/TronKit/Core/Kit.swift
@@ -7,6 +7,7 @@ import HsToolKit
 
 public class Kit {
     private let syncer: Syncer
+    private let transactionSyncer: TransactionSyncer?
     private let accountInfoManager: AccountInfoManager
     private let allowanceManager: AllowanceManager
     private let transactionManager: TransactionManager
@@ -18,21 +19,32 @@ public class Kit {
     public let uniqueId: String
     public let logger: Logger
 
-    init(address: Address, network: Network, uniqueId: String, syncer: Syncer, accountInfoManager: AccountInfoManager, allowanceManager: AllowanceManager, transactionManager: TransactionManager, transactionSender: TransactionSender, feeProvider: FeeProvider, logger: Logger) {
+    init(
+        address: Address, network: Network, uniqueId: String,
+        syncer: Syncer,
+        transactionSyncer: TransactionSyncer?,
+        accountInfoManager: AccountInfoManager,
+        allowanceManager: AllowanceManager,
+        transactionManager: TransactionManager,
+        transactionSender: TransactionSender,
+        feeProvider: FeeProvider,
+        logger: Logger
+    ) {
         self.address = address
         self.network = network
         self.uniqueId = uniqueId
+        self.syncer = syncer
+        self.transactionSyncer = transactionSyncer
         self.accountInfoManager = accountInfoManager
         self.allowanceManager = allowanceManager
         self.transactionManager = transactionManager
         self.transactionSender = transactionSender
-        self.syncer = syncer
         self.feeProvider = feeProvider
         self.logger = logger
     }
 }
 
-// Public API Extension
+// MARK: - Public API
 
 public extension Kit {
     var lastBlockHeight: Int? {
@@ -41,6 +53,10 @@ public extension Kit {
 
     var syncState: SyncState {
         syncer.state
+    }
+
+    var transactionsSyncState: SyncState {
+        transactionSyncer?.state ?? .notSynced(error: SyncError.noTransactionSource)
     }
 
     var accountActive: Bool {
@@ -61,6 +77,13 @@ public extension Kit {
 
     var syncStatePublisher: AnyPublisher<SyncState, Never> {
         syncer.$state.eraseToAnyPublisher()
+    }
+
+    var transactionsSyncStatePublisher: AnyPublisher<SyncState, Never> {
+        if let transactionSyncer {
+            return transactionSyncer.$state.eraseToAnyPublisher()
+        }
+        return Just(.notSynced(error: SyncError.noTransactionSource)).eraseToAnyPublisher()
     }
 
     var trxBalancePublisher: AnyPublisher<BigUInt, Never> {
@@ -103,7 +126,6 @@ public extension Kit {
         guard let contract = try? ContractHelper.contractsFrom(jsonMap: createdTransaction.rawData.contract).first else {
             throw SendError.notSupportedContract
         }
-
         return try await estimateFee(contract: contract)
     }
 
@@ -125,14 +147,9 @@ public extension Kit {
         let parameter = ContractMethodHelper.encodedABI(methodId: Data(), arguments: transferMethod.arguments).hs.hex
 
         return TriggerSmartContract(
-            data: data,
-            ownerAddress: address,
-            contractAddress: contractAddress,
-            callValue: nil,
-            callTokenValue: nil,
-            tokenId: nil,
-            functionSelector: TransferMethod.methodSignature,
-            parameter: parameter
+            data: data, ownerAddress: address, contractAddress: contractAddress,
+            callValue: nil, callTokenValue: nil, tokenId: nil,
+            functionSelector: TransferMethod.methodSignature, parameter: parameter
         )
     }
 
@@ -142,15 +159,14 @@ public extension Kit {
         let parameter = ContractMethodHelper.encodedABI(methodId: Data(), arguments: approveMethod.arguments).hs.hex
 
         return TriggerSmartContract(
-            data: data,
-            ownerAddress: address,
-            contractAddress: contractAddress,
-            callValue: nil,
-            callTokenValue: nil,
-            tokenId: nil,
-            functionSelector: ApproveMethod.methodSignature,
-            parameter: parameter
+            data: data, ownerAddress: address, contractAddress: contractAddress,
+            callValue: nil, callTokenValue: nil, tokenId: nil,
+            functionSelector: ApproveMethod.methodSignature, parameter: parameter
         )
+    }
+
+    func watchTrc20(contractAddress: Address) {
+        accountInfoManager.watchTrc20(contractAddress: contractAddress)
     }
 
     func tagTokens() -> [TagToken] {
@@ -173,20 +189,25 @@ public extension Kit {
 
     func start() {
         syncer.start()
+        transactionSyncer?.sync()
     }
 
     func stop() {
         syncer.stop()
+        transactionSyncer?.stop()
     }
 
     func refresh() {
         syncer.refresh()
+        transactionSyncer?.sync()
     }
 
     func fetchTransaction(hash _: Data) async throws -> FullTransaction {
         throw SyncError.notStarted
     }
 }
+
+// MARK: - Factory
 
 public extension Kit {
     static func clear(exceptFor excludedFiles: [String]) throws {
@@ -200,11 +221,36 @@ public extension Kit {
         }
     }
 
-    static func instance(address: Address, network: Network, walletId: String, apiKey: String?, minLogLevel: Logger.Level = .error) throws -> Kit {
+    static func instance(
+        address: Address,
+        network: Network,
+        walletId: String,
+        rpcSource: RpcSource,
+        transactionSource: TransactionSource?,
+        minLogLevel: Logger.Level = .error
+    ) throws -> Kit {
         let logger = Logger(minLogLevel: minLogLevel)
         let uniqueId = "\(walletId)-\(network.rawValue)"
-
         let networkManager = NetworkManager(logger: logger)
+
+        // Build RPC + Node provider from RpcSource
+        let tronProvider = TronGridProvider(
+            networkManager: networkManager,
+            baseUrl: rpcSource.urls[0].absoluteString,
+            apiKey: rpcSource.apiKey,
+            auth: rpcSource.auth
+        )
+
+        // Build history provider from TransactionSource
+        let historyProvider: IHistoryProvider? = transactionSource.map { source in
+            switch source.type {
+            case let .tronGrid(url, apiKey):
+                return TronGridProvider(networkManager: networkManager, baseUrl: url.absoluteString, apiKey: apiKey)
+            case let .tronScan(url, apiKey):
+                return TronScanProvider(networkManager: networkManager, baseUrl: url.absoluteString, apiKey: apiKey)
+            }
+        }
+
         let reachabilityManager = ReachabilityManager()
         let databaseDirectoryUrl = try dataDirectoryUrl()
         let syncerStorage = SyncerStorage(databaseDirectoryUrl: databaseDirectoryUrl, databaseFileName: "syncer-state-storage-\(uniqueId)")
@@ -215,18 +261,32 @@ public extension Kit {
         let decorationManager = DecorationManager(userAddress: address, storage: transactionStorage)
         let transactionManager = TransactionManager(userAddress: address, storage: transactionStorage, decorationManager: decorationManager)
 
-        let tronGridProvider = TronGridProvider(networkManager: networkManager, baseUrl: providerUrl(network: network), apiKey: apiKey)
-        let chainParameterManager = ChainParameterManager(tronGridProvider: tronGridProvider, storage: syncerStorage)
-        let feeProvider = FeeProvider(tronGridProvider: tronGridProvider, chainParameterManager: chainParameterManager)
+        let chainParameterManager = ChainParameterManager(nodeApiProvider: tronProvider, storage: syncerStorage)
+        let feeProvider = FeeProvider(rpcApiProvider: tronProvider, nodeApiProvider: tronProvider, chainParameterManager: chainParameterManager)
 
         let syncTimer = SyncTimer(reachabilityManager: reachabilityManager, syncInterval: 30)
-        let syncer = Syncer(accountInfoManager: accountInfoManager, transactionManager: transactionManager, chainParameterManager: chainParameterManager, syncTimer: syncTimer, tronGridProvider: tronGridProvider, storage: syncerStorage, address: address)
-        let transactionSender = TransactionSender(tronGridProvider: tronGridProvider)
-        let allowanceManager = AllowanceManager(tronGridProvider: tronGridProvider, address: address)
+        let syncer = Syncer(
+            accountInfoManager: accountInfoManager,
+            chainParameterManager: chainParameterManager,
+            syncTimer: syncTimer,
+            rpcApiProvider: tronProvider,
+            nodeApiProvider: tronProvider,
+            historyProvider: historyProvider,
+            storage: syncerStorage,
+            address: address
+        )
+
+        let transactionSyncer = historyProvider.map {
+            TransactionSyncer(historyProvider: $0, transactionManager: transactionManager, storage: syncerStorage, address: address)
+        }
+
+        let transactionSender = TransactionSender(nodeApiProvider: tronProvider)
+        let allowanceManager = AllowanceManager(rpcApiProvider: tronProvider, address: address)
 
         let kit = Kit(
             address: address, network: network, uniqueId: uniqueId,
             syncer: syncer,
+            transactionSyncer: transactionSyncer,
             accountInfoManager: accountInfoManager,
             allowanceManager: allowanceManager,
             transactionManager: transactionManager,
@@ -241,37 +301,27 @@ public extension Kit {
     }
 
     static func call(networkManager: NetworkManager, network: Network, contractAddress: Address, data: Data, apiKey: String?) async throws -> Data {
-        let tronGridProvider = TronGridProvider(networkManager: networkManager, baseUrl: providerUrl(network: network), apiKey: apiKey)
-        let rpc = CallJsonRpc(contractAddress: contractAddress, data: data)
-
-        return try await tronGridProvider.fetch(rpc: rpc)
+        let provider = TronGridProvider(networkManager: networkManager, baseUrl: network.tronGridUrl, apiKey: apiKey)
+        return try await provider.fetch(rpc: CallJsonRpc(contractAddress: contractAddress, data: data))
     }
 
     private static func dataDirectoryUrl() throws -> URL {
         let fileManager = FileManager.default
-
         let url = try fileManager
             .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
             .appendingPathComponent("tron-kit", isDirectory: true)
-
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
-
         return url
     }
-
-    private static func providerUrl(network: Network) -> String {
-        switch network {
-        case .mainNet: return "https://api.trongrid.io/"
-        case .nileTestnet: return "https://nile.trongrid.io/"
-        case .shastaTestnet: return "https://api.shasta.trongrid.io/"
-        }
-    }
 }
+
+// MARK: - Error Types
 
 public extension Kit {
     enum SyncError: Error {
         case notStarted
         case noNetworkConnection
+        case noTransactionSource
     }
 
     enum SendError: Error {

--- a/Sources/TronKit/Core/Syncer.swift
+++ b/Sources/TronKit/Core/Syncer.swift
@@ -1,28 +1,38 @@
+import BigInt
 import HsExtensions
 
 class Syncer {
     private var tasks = Set<AnyTask>()
 
     private let accountInfoManager: AccountInfoManager
-    private let transactionManager: TransactionManager
     private let chainParameterManager: ChainParameterManager
     private let syncTimer: SyncTimer
-    private let tronGridProvider: TronGridProvider
+    private let rpcApiProvider: IRpcApiProvider
+    private let nodeApiProvider: INodeApiProvider
+    private let historyProvider: IHistoryProvider?
     private let storage: SyncerStorage
     private let address: Address
-    private var syncing: Bool = false
+    private var syncing = false
 
     @DistinctPublished private(set) var state: SyncState = .notSynced(error: Kit.SyncError.notStarted)
     @DistinctPublished private(set) var lastBlockHeight: Int = 0
 
-    init(accountInfoManager: AccountInfoManager, transactionManager: TransactionManager, chainParameterManager: ChainParameterManager,
-         syncTimer: SyncTimer, tronGridProvider: TronGridProvider, storage: SyncerStorage, address: Address)
-    {
+    init(
+        accountInfoManager: AccountInfoManager,
+        chainParameterManager: ChainParameterManager,
+        syncTimer: SyncTimer,
+        rpcApiProvider: IRpcApiProvider,
+        nodeApiProvider: INodeApiProvider,
+        historyProvider: IHistoryProvider?,
+        storage: SyncerStorage,
+        address: Address
+    ) {
         self.accountInfoManager = accountInfoManager
-        self.transactionManager = transactionManager
         self.chainParameterManager = chainParameterManager
         self.syncTimer = syncTimer
-        self.tronGridProvider = tronGridProvider
+        self.rpcApiProvider = rpcApiProvider
+        self.nodeApiProvider = nodeApiProvider
+        self.historyProvider = historyProvider
         self.storage = storage
         self.address = address
 
@@ -46,10 +56,6 @@ class Syncer {
 }
 
 extension Syncer {
-    var source: String {
-        "RPC \(tronGridProvider.source)"
-    }
-
     func start() {
         syncChainParameters()
         syncTimer.start()
@@ -61,10 +67,8 @@ extension Syncer {
 
     func refresh() {
         switch syncTimer.state {
-        case .ready:
-            sync()
-        case .notReady:
-            syncTimer.start()
+        case .ready: sync()
+        case .notReady: syncTimer.start()
         }
     }
 }
@@ -82,75 +86,72 @@ extension Syncer: ISyncTimerDelegate {
     }
 
     func sync() {
-        Task { [weak self, lastBlockHeight, tronGridProvider, address, storage] in
+        Task { [weak self, lastBlockHeight, rpcApiProvider, nodeApiProvider, historyProvider, address, storage] in
             do {
-                guard let syncer = self, !syncer.syncing else {
-                    return
-                }
+                guard let syncer = self, !syncer.syncing else { return }
                 syncer.syncing = true
 
-                let address = address.base58
-                let newLastBlockHeight = try await tronGridProvider.fetch(rpc: BlockNumberJsonRpc())
+                let newLastBlockHeight = try await rpcApiProvider.fetch(rpc: BlockNumberJsonRpc())
 
                 guard newLastBlockHeight != lastBlockHeight else {
                     self?.set(state: .synced)
                     return
                 }
+
                 storage.save(lastBlockHeight: newLastBlockHeight)
                 self?.lastBlockHeight = newLastBlockHeight
 
-                let response = try await tronGridProvider.fetchAccountInfo(address: address)
-                self?.accountInfoManager.handle(accountInfoResponse: response)
-
-                let lastTrc20TxTimestamp = storage.lastTransactionTimestamp(apiPath: TronGridProvider.ApiPath.transactionsTrc20.rawValue) ?? 0
-                var fingerprint: String?
-                var completed = false
-                repeat {
-                    let fetchResult = try await tronGridProvider.fetchTrc20Transactions(
-                        address: address,
-                        minTimestamp: lastTrc20TxTimestamp + 1000,
-                        fingerprint: fingerprint
-                    )
-
-                    if let lastTransaction = fetchResult.transactions.last {
-                        self?.transactionManager.save(trc20TransferResponses: fetchResult.transactions)
-                        storage.save(apiPath: TronGridProvider.ApiPath.transactionsTrc20.rawValue, lastTransactionTimestamp: lastTransaction.blockTimestamp)
-                    }
-                    fingerprint = fetchResult.fingerprint
-                    completed = fetchResult.completed
-                } while !completed
-
-                let lastTxTimestamp = storage.lastTransactionTimestamp(apiPath: TronGridProvider.ApiPath.transactions.rawValue) ?? 0
-                fingerprint = nil
-                completed = false
-                repeat {
-                    let fetchResult = try await tronGridProvider.fetchTransactions(
-                        address: address,
-                        minTimestamp: lastTxTimestamp + 1000,
-                        fingerprint: fingerprint
-                    )
-
-                    if let lastTransaction = fetchResult.transactions.last {
-                        self?.transactionManager.save(transactionResponses: fetchResult.transactions)
-                        storage.save(apiPath: TronGridProvider.ApiPath.transactions.rawValue, lastTransactionTimestamp: lastTransaction.blockTimestamp)
-                    }
-
-                    fingerprint = fetchResult.fingerprint
-                    completed = fetchResult.completed
-                } while !completed
-
-                self?.transactionManager.process(initial: lastTxTimestamp == 0 || lastTrc20TxTimestamp == 0)
-                self?.set(state: .synced)
-            } catch {
-                if let requestError = error as? TronGridProvider.RequestError,
-                   case .failedToFetchAccountInfo = requestError
-                {
-                    self?.accountInfoManager.handleInactiveAccount()
-                    self?.set(state: .synced)
+                if let historyProvider {
+                    try await syncer.syncAccountViaHistory(address: address.base58, historyProvider: historyProvider)
                 } else {
-                    self?.set(state: .notSynced(error: error))
+                    try await syncer.syncAccountViaRpc(address: address.base58, rpcApiProvider: rpcApiProvider, nodeApiProvider: nodeApiProvider)
                 }
+            } catch {
+                self?.set(state: .notSynced(error: error))
             }
         }.store(in: &tasks)
+    }
+
+    // Fetch TRX + all TRC20 balances via history provider (single call).
+    // Also ensures watched tokens with zero balance are explicitly stored.
+    private func syncAccountViaHistory(address: String, historyProvider: IHistoryProvider) async throws {
+        do {
+            let response = try await historyProvider.fetchAccountInfo(address: address)
+            accountInfoManager.handle(accountInfoResponse: response)
+
+            // fetchAccountInfo only returns non-zero balances. For watched tokens absent
+            // from the response, explicitly store 0 so they appear in the UI.
+            for contractAddress in accountInfoManager.trc20AddressesToSync() {
+                if response.trc20[contractAddress] == nil {
+                    accountInfoManager.handle(trc20Balance: .zero, contractAddress: contractAddress)
+                }
+            }
+        } catch TronGridProvider.RequestError.failedToFetchAccountInfo {
+            accountInfoManager.handleInactiveAccount()
+        }
+        set(state: .synced)
+    }
+
+    // Fetch TRX balance via node API + TRC20 balances via balanceOf RPC calls.
+    // Covers both previously seen tokens and manually watched tokens.
+    private func syncAccountViaRpc(address: String, rpcApiProvider: IRpcApiProvider, nodeApiProvider: INodeApiProvider) async throws {
+        guard let account = try await nodeApiProvider.fetchAccount(address: address) else {
+            accountInfoManager.handleInactiveAccount()
+            set(state: .synced)
+            return
+        }
+
+        accountInfoManager.handle(trxBalance: account.balance)
+
+        for contractAddress in accountInfoManager.trc20AddressesToSync() {
+            let methodData = BalanceOfMethod(owner: self.address).encodedABI()
+            let callRpc = CallJsonRpc(contractAddress: contractAddress, data: methodData)
+
+            if let response = try? await rpcApiProvider.fetch(rpc: callRpc), response.count >= 32 {
+                accountInfoManager.handle(trc20Balance: BigUInt(response[0 ... 31]), contractAddress: contractAddress)
+            }
+        }
+
+        set(state: .synced)
     }
 }

--- a/Sources/TronKit/Core/TransactionSender.swift
+++ b/Sources/TronKit/Core/TransactionSender.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 class TransactionSender {
-    private let tronGridProvider: TronGridProvider
+    private let nodeApiProvider: INodeApiProvider
 
-    init(tronGridProvider: TronGridProvider) {
-        self.tronGridProvider = tronGridProvider
+    init(nodeApiProvider: INodeApiProvider) {
+        self.nodeApiProvider = nodeApiProvider
     }
 }
 
@@ -18,7 +18,11 @@ extension TransactionSender {
 
         switch contract {
         case let transfer as TransferContract:
-            createdTransaction = try await tronGridProvider.createTransaction(ownerAddress: transfer.ownerAddress.hex, toAddress: transfer.toAddress.hex, amount: transfer.amount)
+            createdTransaction = try await nodeApiProvider.createTransaction(
+                ownerAddress: transfer.ownerAddress.hex,
+                toAddress: transfer.toAddress.hex,
+                amount: transfer.amount
+            )
 
         case let smartContract as TriggerSmartContract:
             guard let functionSelector = smartContract.functionSelector,
@@ -28,11 +32,14 @@ extension TransactionSender {
                 throw Kit.SendError.invalidParameter
             }
 
-            createdTransaction = try await tronGridProvider.triggerSmartContract(
+            createdTransaction = try await nodeApiProvider.triggerSmartContract(
                 ownerAddress: smartContract.ownerAddress.hex,
                 contractAddress: smartContract.contractAddress.hex,
                 functionSelector: functionSelector,
                 parameter: parameter,
+                callValue: smartContract.callValue,
+                callTokenValue: smartContract.callTokenValue,
+                tokenId: smartContract.tokenId,
                 feeLimit: feeLimit
             )
 
@@ -54,13 +61,13 @@ extension TransactionSender {
         transaction.rawData = rawData
         transaction.signature = [signature]
 
-        try await tronGridProvider.broadcastTransaction(hexData: transaction.serializedData())
+        try await nodeApiProvider.broadcastTransaction(hexData: transaction.serializedData())
 
         return createdTransaction
     }
 
     func broadcastTransaction(createdTransaction: CreatedTransactionResponse, signer: Signer) async throws {
         let signature = try signer.signature(hash: createdTransaction.txID)
-        return try await tronGridProvider.broadcastTransaction(createdTransaction: createdTransaction, signature: signature)
+        return try await nodeApiProvider.broadcastTransaction(createdTransaction: createdTransaction, signature: signature)
     }
 }

--- a/Sources/TronKit/Core/TransactionSyncer.swift
+++ b/Sources/TronKit/Core/TransactionSyncer.swift
@@ -1,0 +1,102 @@
+import HsExtensions
+
+class TransactionSyncer {
+    private static let maxTransactionCount = 1000
+
+    private var tasks = Set<AnyTask>()
+
+    private let historyProvider: IHistoryProvider
+    private let transactionManager: TransactionManager
+    private let storage: SyncerStorage
+    private let address: Address
+    private var syncing = false
+
+    @DistinctPublished private(set) var state: SyncState = .notSynced(error: Kit.SyncError.notStarted)
+
+    init(
+        historyProvider: IHistoryProvider,
+        transactionManager: TransactionManager,
+        storage: SyncerStorage,
+        address: Address
+    ) {
+        self.historyProvider = historyProvider
+        self.transactionManager = transactionManager
+        self.storage = storage
+        self.address = address
+    }
+
+    private func set(state: SyncState) {
+        self.state = state
+
+        if case .syncing = state {} else {
+            syncing = false
+        }
+    }
+}
+
+extension TransactionSyncer {
+    func sync() {
+        Task { [weak self, historyProvider, address, storage] in
+            do {
+                guard let syncer = self, !syncer.syncing else { return }
+                syncer.syncing = true
+                syncer.state = .syncing(progress: nil)
+
+                let addressBase58 = address.base58
+                var totalFetched = 0
+
+                // Fetch TRC20 transfers
+                let lastTrc20Timestamp = storage.lastTransactionTimestamp(apiPath: "trc20") ?? 0
+                var cursor: String? = nil
+
+                repeat {
+                    let (transactions, nextCursor) = try await historyProvider.fetchTrc20Transactions(
+                        address: addressBase58,
+                        minTimestamp: lastTrc20Timestamp + 1,
+                        cursor: cursor
+                    )
+
+                    if let last = transactions.last {
+                        syncer.transactionManager.save(trc20TransferResponses: transactions)
+                        storage.save(apiPath: "trc20", lastTransactionTimestamp: last.blockTimestamp)
+                    }
+
+                    totalFetched += transactions.count
+                    cursor = nextCursor
+                } while cursor != nil && totalFetched < Self.maxTransactionCount
+
+                // Fetch regular transactions (separate cap)
+                totalFetched = 0
+                let lastTxTimestamp = storage.lastTransactionTimestamp(apiPath: "transactions") ?? 0
+                cursor = nil
+                let isInitial = lastTxTimestamp == 0 || lastTrc20Timestamp == 0
+
+                repeat {
+                    let (transactions, nextCursor) = try await historyProvider.fetchTransactions(
+                        address: addressBase58,
+                        minTimestamp: lastTxTimestamp + 1,
+                        cursor: cursor
+                    )
+
+                    if let last = transactions.last {
+                        syncer.transactionManager.save(transactionResponses: transactions)
+                        storage.save(apiPath: "transactions", lastTransactionTimestamp: last.blockTimestamp)
+                    }
+
+                    totalFetched += transactions.count
+                    cursor = nextCursor
+                } while cursor != nil && totalFetched < Self.maxTransactionCount
+
+                syncer.transactionManager.process(initial: isInitial)
+                syncer.set(state: .synced)
+            } catch {
+                self?.set(state: .notSynced(error: error))
+            }
+        }.store(in: &tasks)
+    }
+
+    func stop() {
+        tasks = Set()
+        set(state: .notSynced(error: Kit.SyncError.notStarted))
+    }
+}

--- a/Sources/TronKit/Models/Network.swift
+++ b/Sources/TronKit/Models/Network.swift
@@ -2,4 +2,12 @@ import Foundation
 
 public enum Network: String {
     case mainNet, shastaTestnet, nileTestnet
+
+    var tronGridUrl: String {
+        switch self {
+        case .mainNet: return "https://api.trongrid.io/"
+        case .nileTestnet: return "https://nile.trongrid.io/"
+        case .shastaTestnet: return "https://api.shasta.trongrid.io/"
+        }
+    }
 }

--- a/Sources/TronKit/Models/RpcSource.swift
+++ b/Sources/TronKit/Models/RpcSource.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct RpcSource {
+    let urls: [URL]
+    let apiKey: String?
+    let auth: String?
+
+    public init(urls: [URL], apiKey: String? = nil, auth: String? = nil) {
+        self.urls = urls
+        self.apiKey = apiKey
+        self.auth = auth
+    }
+
+    public static func tronGrid(network: Network, apiKey: String?) -> RpcSource {
+        RpcSource(urls: [URL(string: network.tronGridUrl)!], apiKey: apiKey)
+    }
+}

--- a/Sources/TronKit/Models/TransactionSource.swift
+++ b/Sources/TronKit/Models/TransactionSource.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct TransactionSource {
+    public let name: String
+    public let type: SourceType
+
+    public enum SourceType {
+        case tronGrid(url: URL, apiKey: String?)
+        case tronScan(url: URL, apiKey: String?)
+    }
+
+    public static func tronGrid(network: Network, apiKey: String?) -> TransactionSource {
+        TransactionSource(
+            name: "TronGrid",
+            type: .tronGrid(url: URL(string: network.tronGridUrl)!, apiKey: apiKey)
+        )
+    }
+
+    public static func tronScan(apiKey: String?) -> TransactionSource {
+        TransactionSource(
+            name: "TronScan",
+            type: .tronScan(url: URL(string: "https://apilist.tronscanapi.com/api/")!, apiKey: apiKey)
+        )
+    }
+}

--- a/Sources/TronKit/Network/IHistoryProvider.swift
+++ b/Sources/TronKit/Network/IHistoryProvider.swift
@@ -1,0 +1,5 @@
+protocol IHistoryProvider {
+    func fetchAccountInfo(address: String) async throws -> AccountInfoResponse
+    func fetchTransactions(address: String, minTimestamp: Int, cursor: String?) async throws -> ([ITransactionResponse], nextCursor: String?)
+    func fetchTrc20Transactions(address: String, minTimestamp: Int, cursor: String?) async throws -> ([Trc20TransactionResponse], nextCursor: String?)
+}

--- a/Sources/TronKit/Network/INodeApiProvider.swift
+++ b/Sources/TronKit/Network/INodeApiProvider.swift
@@ -1,0 +1,20 @@
+import BigInt
+import Foundation
+
+protocol INodeApiProvider {
+    func fetchAccount(address: String) async throws -> NodeAccountResponse?
+    func fetchChainParameters() async throws -> [ChainParameterResponse]
+    func createTransaction(ownerAddress: String, toAddress: String, amount: Int) async throws -> CreatedTransactionResponse
+    func triggerSmartContract(
+        ownerAddress: String, contractAddress: String, functionSelector: String, parameter: String,
+        callValue: Int?, callTokenValue: Int?, tokenId: Int?,
+        feeLimit: Int
+    ) async throws -> CreatedTransactionResponse
+    func broadcastTransaction(hexData: Data) async throws
+    func broadcastTransaction(createdTransaction: CreatedTransactionResponse, signature: Data) async throws
+    func estimateEnergy(ownerAddress: String, contractAddress: String, functionSelector: String, parameter: String) async throws -> Int
+}
+
+struct NodeAccountResponse {
+    let balance: BigUInt
+}

--- a/Sources/TronKit/Network/IRpcApiProvider.swift
+++ b/Sources/TronKit/Network/IRpcApiProvider.swift
@@ -1,0 +1,3 @@
+protocol IRpcApiProvider {
+    func fetch<T>(rpc: JsonRpc<T>) async throws -> T
+}

--- a/Sources/TronKit/Signer/Signer.swift
+++ b/Sources/TronKit/Signer/Signer.swift
@@ -22,7 +22,7 @@ public extension Signer {
     }
 
     static func instance(privateKey: Data) throws -> Signer {
-        try Signer(privateKey: privateKey)
+        Signer(privateKey: privateKey)
     }
 
     static func address(seed: Data) throws -> Address {

--- a/Sources/TronKit/Storage/AccountInfoStorage.swift
+++ b/Sources/TronKit/Storage/AccountInfoStorage.swift
@@ -63,4 +63,15 @@ extension AccountInfoStorage {
             try Balance.filter(Balance.Columns.id != trxId).deleteAll(db)
         }
     }
+
+    func allTrc20Addresses() -> [String] {
+        let prefix = "trc20/"
+        return (try! dbPool.read { db in
+            try Balance.filter(Balance.Columns.id != trxId).fetchAll(db)
+        }).compactMap { balance in
+            guard balance.id.hasPrefix(prefix) else { return nil }
+            return String(balance.id.dropFirst(prefix.count))
+        }
+    }
+
 }

--- a/Sources/TronKit/TronGrid/ExtensionApi/AccountInfoResponse.swift
+++ b/Sources/TronKit/TronGrid/ExtensionApi/AccountInfoResponse.swift
@@ -6,6 +6,11 @@ struct AccountInfoResponse: ImmutableMappable {
     let balance: Int
     let trc20: [Address: BigUInt]
 
+    init(balance: Int, trc20: [Address: BigUInt]) {
+        self.balance = balance
+        self.trc20 = trc20
+    }
+
     public init(map: Map) throws {
         balance = (try? map.value("balance")) ?? 0
 

--- a/Sources/TronKit/TronGrid/ExtensionApi/TransactionResponse.swift
+++ b/Sources/TronKit/TronGrid/ExtensionApi/TransactionResponse.swift
@@ -32,6 +32,22 @@ struct TransactionResponse: ImmutableMappable, ITransactionResponse {
         rawData = try map.value("raw_data")
     }
 
+    init(txId: Data, blockTimestamp: Int, blockNumber: Int, ret: [Ret],
+         netUsage: Int, netFee: Int, energyUsage: Int, energyFee: Int, energyUsageTotal: Int,
+         contractsMap: Any?) {
+        self.txId = txId
+        self.blockTimestamp = blockTimestamp
+        self.blockNumber = blockNumber
+        self.ret = ret
+        self.netUsage = netUsage
+        self.netFee = netFee
+        self.energyUsage = energyUsage
+        self.energyFee = energyFee
+        self.energyUsageTotal = energyUsageTotal
+        self.signature = []
+        self.rawData = RawData(contract: contractsMap, refBlockBytes: "", refBlockHash: "", expiration: 0, feeLimit: nil, timestamp: blockTimestamp)
+    }
+
     struct Ret: ImmutableMappable {
         let contractRet: String
         let fee: Int
@@ -39,6 +55,11 @@ struct TransactionResponse: ImmutableMappable, ITransactionResponse {
         public init(map: Map) throws {
             contractRet = try map.value("contractRet")
             fee = try map.value("fee")
+        }
+
+        init(contractRet: String, fee: Int) {
+            self.contractRet = contractRet
+            self.fee = fee
         }
     }
 
@@ -57,6 +78,15 @@ struct TransactionResponse: ImmutableMappable, ITransactionResponse {
             expiration = try map.value("expiration")
             feeLimit = try map.value("fee_limit")
             timestamp = try map.value("timestamp")
+        }
+
+        init(contract: Any?, refBlockBytes: String, refBlockHash: String, expiration: Int, feeLimit: Int?, timestamp: Int) {
+            self.contract = contract
+            self.refBlockBytes = refBlockBytes
+            self.refBlockHash = refBlockHash
+            self.expiration = expiration
+            self.feeLimit = feeLimit
+            self.timestamp = timestamp
         }
     }
 }

--- a/Sources/TronKit/TronGrid/ExtensionApi/Trc20TransactionResponse.swift
+++ b/Sources/TronKit/TronGrid/ExtensionApi/Trc20TransactionResponse.swift
@@ -20,6 +20,16 @@ struct Trc20TransactionResponse: ImmutableMappable {
         type = try map.value("type")
         value = try map.value("value", using: StringBigUIntTransform())
     }
+
+    init(transactionId: Data, blockTimestamp: Int, from: Address, to: Address, type: String, value: BigUInt, tokenInfo: TokenInfo) {
+        self.transactionId = transactionId
+        self.blockTimestamp = blockTimestamp
+        self.from = from
+        self.to = to
+        self.type = type
+        self.value = value
+        self.tokenInfo = tokenInfo
+    }
 }
 
 extension Trc20TransactionResponse {
@@ -34,6 +44,13 @@ extension Trc20TransactionResponse {
             address = try map.value("address", using: StringAddressTransform())
             decimals = try map.value("decimals")
             name = try map.value("name")
+        }
+
+        init(symbol: String, address: Address, decimals: Int, name: String) {
+            self.symbol = symbol
+            self.address = address
+            self.decimals = decimals
+            self.name = name
         }
     }
 }

--- a/Sources/TronKit/TronGrid/FullNode/ChainParameterResponse.swift
+++ b/Sources/TronKit/TronGrid/FullNode/ChainParameterResponse.swift
@@ -5,7 +5,7 @@ struct ChainParameterResponse: ImmutableMappable {
     let key: String
     let value: Int?
 
-    public init(map: Map) throws {
+    init(map: Map) throws {
         key = try map.value("key")
         value = try map.value("value")
     }

--- a/Sources/TronKit/TronGrid/TronGridProvider.swift
+++ b/Sources/TronKit/TronGrid/TronGridProvider.swift
@@ -11,14 +11,19 @@ class TronGridProvider {
     private var currentRpcId = 0
     private let pageLimit = 200
 
-    init(networkManager: NetworkManager, baseUrl: String, apiKey: String?) {
+    init(networkManager: NetworkManager, baseUrl: String, apiKey: String?, auth: String? = nil) {
         self.networkManager = networkManager
-        self.baseUrl = baseUrl
+        self.baseUrl = baseUrl.hasSuffix("/") ? baseUrl : baseUrl + "/"
 
         var headers = HTTPHeaders()
 
         if let apiKey {
             headers.add(.init(name: "TRON-PRO-API-KEY", value: apiKey))
+        }
+
+        if let auth {
+            let base64 = Data(auth.utf8).base64EncodedString()
+            headers.add(.init(name: "Authorization", value: "Basic \(base64)"))
         }
 
         self.headers = headers
@@ -37,9 +42,7 @@ class TronGridProvider {
     }
 
     private func extensionApiFetch(path: String, parameters: Parameters) async throws -> (data: [[String: Any]], meta: [String: Any]) {
-        let urlString = "\(baseUrl)\(path)"
-
-        let json = try await networkManager.fetchJson(url: urlString, method: .get, parameters: parameters, headers: headers, responseCacherBehavior: .doNotCache)
+        let json = try await networkManager.fetchJson(url: "\(baseUrl)\(path)", method: .get, parameters: parameters, headers: headers, responseCacherBehavior: .doNotCache)
 
         guard let map = json as? [String: Any] else {
             throw RequestError.invalidResponse
@@ -60,14 +63,18 @@ class TronGridProvider {
         return (data, meta)
     }
 
-    private func requestNodeApiFetch(path: String, parameters: Parameters) async throws -> [String: Any] {
-        let urlString = "\(baseUrl)\(path)"
-
-        let json = try await networkManager.fetchJson(url: urlString, method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers, responseCacherBehavior: .doNotCache)
+    private func nodeApiFetch(path: String, parameters: Parameters) async throws -> [String: Any] {
+        let json = try await networkManager.fetchJson(url: "\(baseUrl)\(path)", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers, responseCacherBehavior: .doNotCache)
 
         guard let map = json as? [String: Any] else {
             throw RequestError.invalidResponse
         }
+
+        return map
+    }
+
+    private func nodeApiFetchChecked(path: String, parameters: Parameters) async throws -> [String: Any] {
+        let map = try await nodeApiFetch(path: path, parameters: parameters)
 
         guard let resultMap = map["result"] as? [String: Any],
               let successResult = resultMap["result"] as? Bool
@@ -106,7 +113,11 @@ extension TronGridProvider {
     var source: String {
         baseUrl
     }
+}
 
+// MARK: - IRpcApiProvider
+
+extension TronGridProvider: IRpcApiProvider {
     func fetch<T>(rpc: JsonRpc<T>) async throws -> T {
         currentRpcId += 1
 
@@ -118,89 +129,28 @@ extension TronGridProvider {
 
         return try rpc.parse(response: rpcResponse)
     }
+}
 
-    func fetchAccountInfo(address: String) async throws -> AccountInfoResponse {
-        let result = try await extensionApiFetch(path: "v1/accounts/\(address)", parameters: [:])
+// MARK: - INodeApiProvider
 
-        guard !result.data.isEmpty else {
-            throw RequestError.failedToFetchAccountInfo
+extension TronGridProvider: INodeApiProvider {
+    func fetchAccount(address: String) async throws -> NodeAccountResponse? {
+        let map = try await nodeApiFetch(path: "wallet/getaccount", parameters: ["address": address, "visible": true])
+
+        // Empty object {} or missing balance means account does not exist / is inactive
+        guard let balance = map["balance"] as? Int else {
+            return nil
         }
 
-        return try AccountInfoResponse(JSON: result.data[0])
-    }
-
-    func fetchTransactions(address: String, minTimestamp: Int, fingerprint: String?) async throws -> (transactions: [ITransactionResponse], fingerprint: String?, completed: Bool) {
-        let path = "v1/accounts/\(address)/\(ApiPath.transactions.rawValue)"
-        var parameters: Parameters = [
-            "only_confirmed": true,
-            "order_by": "block_timestamp,asc",
-            "limit": pageLimit,
-            "min_timestamp": minTimestamp,
-        ]
-
-        fingerprint.flatMap { parameters["fingerprint"] = $0 }
-
-        let result = try await extensionApiFetch(path: path, parameters: parameters)
-        let transactions = result.data.compactMap { json -> ITransactionResponse? in
-            if json["internal_tx_id"] is String {
-                return try? InternalTransactionResponse(JSON: json)
-            } else {
-                return try? TransactionResponse(JSON: json)
-            }
-        }
-
-        let newFingerprint = result.meta["fingerprint"] as? String
-        let completed = transactions.count < pageLimit
-
-        return (transactions: transactions, fingerprint: newFingerprint, completed: completed)
-    }
-
-    func fetchTrc20Transactions(address: String, minTimestamp: Int, fingerprint: String?) async throws -> (transactions: [Trc20TransactionResponse], fingerprint: String?, completed: Bool) {
-        let path = "v1/accounts/\(address)/\(ApiPath.transactionsTrc20.rawValue)"
-        var parameters: Parameters = [
-            "only_confirmed": true,
-            "order_by": "block_timestamp,asc",
-            "limit": pageLimit,
-            "min_timestamp": minTimestamp,
-        ]
-
-        fingerprint.flatMap { parameters["fingerprint"] = $0 }
-
-        let result = try await extensionApiFetch(path: path, parameters: parameters)
-        let transactions = result.data.compactMap { try? Trc20TransactionResponse(JSON: $0) }
-        let fingerprint = result.meta["fingerprint"] as? String
-        let completed = transactions.count < pageLimit
-
-        return (transactions: transactions, fingerprint: fingerprint, completed: completed)
-    }
-
-    func estimateEnergy(ownerAddress: String, contractAddress: String, functionSelector: String, parameter: String) async throws -> Int {
-        let path = "wallet/estimateenergy"
-        let parameters: Parameters = [
-            "owner_address": ownerAddress,
-            "contract_address": contractAddress,
-            "function_selector": functionSelector,
-            "parameter": parameter,
-        ]
-
-        let result = try await requestNodeApiFetch(path: path, parameters: parameters)
-
-        guard let energyRequired = result["energy_required"] as? Int else {
-            throw RequestError.invalidResponse
-        }
-
-        return energyRequired
+        return NodeAccountResponse(balance: BigUInt(balance))
     }
 
     func fetchChainParameters() async throws -> [ChainParameterResponse] {
-        let urlString = "\(baseUrl)wallet/getchainparameters"
-        let json = try await networkManager.fetchJson(url: urlString, method: .get, parameters: [:], responseCacherBehavior: .doNotCache)
+        let json = try await networkManager.fetchJson(url: "\(baseUrl)wallet/getchainparameters", method: .get, parameters: [:], headers: headers, responseCacherBehavior: .doNotCache)
 
-        guard let map = json as? [String: Any] else {
-            throw RequestError.invalidResponse
-        }
-
-        guard let chainParameter = map["chainParameter"] as? [[String: Any]] else {
+        guard let map = json as? [String: Any],
+              let chainParameter = map["chainParameter"] as? [[String: Any]]
+        else {
             throw RequestError.invalidResponse
         }
 
@@ -208,13 +158,14 @@ extension TronGridProvider {
     }
 
     func createTransaction(ownerAddress: String, toAddress: String, amount: Int) async throws -> CreatedTransactionResponse {
-        let urlString = "\(baseUrl)wallet/createtransaction"
-        let parameters: Parameters = [
-            "owner_address": ownerAddress,
-            "to_address": toAddress,
-            "amount": amount,
-        ]
-        let json = try await networkManager.fetchJson(url: urlString, method: .post, parameters: parameters, encoding: JSONEncoding.default, responseCacherBehavior: .doNotCache)
+        let json = try await networkManager.fetchJson(
+            url: "\(baseUrl)wallet/createtransaction",
+            method: .post,
+            parameters: ["owner_address": ownerAddress, "to_address": toAddress, "amount": amount],
+            encoding: JSONEncoding.default,
+            headers: headers,
+            responseCacherBehavior: .doNotCache
+        )
 
         guard let map = json as? [String: Any] else {
             throw RequestError.invalidResponse
@@ -228,7 +179,6 @@ extension TronGridProvider {
         callValue: Int? = nil, callTokenValue: Int? = nil, tokenId: Int? = nil,
         feeLimit: Int
     ) async throws -> CreatedTransactionResponse {
-        let path = "wallet/triggersmartcontract"
         var parameters: Parameters = [
             "owner_address": ownerAddress,
             "contract_address": contractAddress,
@@ -241,7 +191,7 @@ extension TronGridProvider {
         callTokenValue.flatMap { parameters["call_token_value"] = $0 }
         tokenId.flatMap { parameters["token_id"] = $0 }
 
-        let json = try await requestNodeApiFetch(path: path, parameters: parameters)
+        let json = try await nodeApiFetchChecked(path: "wallet/triggersmartcontract", parameters: parameters)
 
         guard let transactionMap = json["transaction"] as? [String: Any] else {
             throw RequestError.invalidResponse
@@ -251,25 +201,104 @@ extension TronGridProvider {
     }
 
     func broadcastTransaction(hexData: Data) async throws {
-        let urlString = "\(baseUrl)wallet/broadcasthex"
-        let parameters: Parameters = [
-            "transaction": hexData.hs.hex,
-        ]
-
-        _ = try await networkManager.fetchJson(url: urlString, method: .post, parameters: parameters, encoding: JSONEncoding.default, responseCacherBehavior: .doNotCache)
+        _ = try await networkManager.fetchJson(
+            url: "\(baseUrl)wallet/broadcasthex",
+            method: .post,
+            parameters: ["transaction": hexData.hs.hex],
+            encoding: JSONEncoding.default,
+            headers: headers,
+            responseCacherBehavior: .doNotCache
+        )
     }
 
     func broadcastTransaction(createdTransaction: CreatedTransactionResponse, signature: Data) async throws {
-        let urlString = "\(baseUrl)wallet/broadcasttransaction"
-        let parameters: Parameters = [
-            "visible": createdTransaction.visible ?? false,
-            "txID": createdTransaction.txID.hs.hex,
-            "raw_data": createdTransaction.rawDataMap,
-            "raw_data_hex": createdTransaction.rawDataHex.hs.hex,
-            "signature": [signature.hs.hexString],
+        _ = try await networkManager.fetchJson(
+            url: "\(baseUrl)wallet/broadcasttransaction",
+            method: .post,
+            parameters: [
+                "visible": createdTransaction.visible ?? false,
+                "txID": createdTransaction.txID.hs.hex,
+                "raw_data": createdTransaction.rawDataMap,
+                "raw_data_hex": createdTransaction.rawDataHex.hs.hex,
+                "signature": [signature.hs.hexString],
+            ],
+            encoding: JSONEncoding.default,
+            headers: headers,
+            responseCacherBehavior: .doNotCache
+        )
+    }
+
+    func estimateEnergy(ownerAddress: String, contractAddress: String, functionSelector: String, parameter: String) async throws -> Int {
+        let result = try await nodeApiFetchChecked(
+            path: "wallet/estimateenergy",
+            parameters: [
+                "owner_address": ownerAddress,
+                "contract_address": contractAddress,
+                "function_selector": functionSelector,
+                "parameter": parameter,
+            ]
+        )
+
+        guard let energyRequired = result["energy_required"] as? Int else {
+            throw RequestError.invalidResponse
+        }
+
+        return energyRequired
+    }
+}
+
+// MARK: - IHistoryProvider
+
+extension TronGridProvider: IHistoryProvider {
+    func fetchAccountInfo(address: String) async throws -> AccountInfoResponse {
+        let result = try await extensionApiFetch(path: "v1/accounts/\(address)", parameters: [:])
+
+        guard !result.data.isEmpty else {
+            throw RequestError.failedToFetchAccountInfo
+        }
+
+        return try AccountInfoResponse(JSON: result.data[0])
+    }
+
+    func fetchTransactions(address: String, minTimestamp: Int, cursor: String?) async throws -> ([ITransactionResponse], nextCursor: String?) {
+        let path = "v1/accounts/\(address)/transactions"
+        var parameters: Parameters = [
+            "only_confirmed": true,
+            "order_by": "block_timestamp,asc",
+            "limit": pageLimit,
+            "min_timestamp": minTimestamp,
         ]
 
-        _ = try await networkManager.fetchJson(url: urlString, method: .post, parameters: parameters, encoding: JSONEncoding.default, responseCacherBehavior: .doNotCache)
+        cursor.flatMap { parameters["fingerprint"] = $0 }
+
+        let result = try await extensionApiFetch(path: path, parameters: parameters)
+        let transactions = result.data.compactMap { json -> ITransactionResponse? in
+            if json["internal_tx_id"] is String {
+                return try? InternalTransactionResponse(JSON: json)
+            } else {
+                return try? TransactionResponse(JSON: json)
+            }
+        }
+
+        let nextCursor: String? = transactions.count < pageLimit ? nil : (result.meta["fingerprint"] as? String)
+        return (transactions, nextCursor)
+    }
+
+    func fetchTrc20Transactions(address: String, minTimestamp: Int, cursor: String?) async throws -> ([Trc20TransactionResponse], nextCursor: String?) {
+        let path = "v1/accounts/\(address)/transactions/trc20"
+        var parameters: Parameters = [
+            "only_confirmed": true,
+            "order_by": "block_timestamp,asc",
+            "limit": pageLimit,
+            "min_timestamp": minTimestamp,
+        ]
+
+        cursor.flatMap { parameters["fingerprint"] = $0 }
+
+        let result = try await extensionApiFetch(path: path, parameters: parameters)
+        let transactions = result.data.compactMap { try? Trc20TransactionResponse(JSON: $0) }
+        let nextCursor: String? = transactions.count < pageLimit ? nil : (result.meta["fingerprint"] as? String)
+        return (transactions, nextCursor)
     }
 }
 
@@ -279,12 +308,5 @@ extension TronGridProvider {
         case invalidStatus
         case failedToFetchAccountInfo
         case fullNodeApiError(code: String, message: String)
-    }
-}
-
-extension TronGridProvider {
-    enum ApiPath: String {
-        case transactions
-        case transactionsTrc20 = "transactions/trc20"
     }
 }

--- a/Sources/TronKit/TronScan/TronScanProvider.swift
+++ b/Sources/TronKit/TronScan/TronScanProvider.swift
@@ -1,0 +1,240 @@
+import BigInt
+import Foundation
+import HsToolKit
+
+class TronScanProvider {
+    private let networkManager: NetworkManager
+    private let baseUrl: String
+    private let apiKey: String?
+    private let pageLimit = 50
+
+    // Cursor format: "{effectiveMinTimestamp}:{start}"
+    // When approaching the 10K offset cap, effectiveMinTimestamp shifts to the last-seen timestamp
+    // so the next window starts fresh from that point.
+    private struct Cursor {
+        let effectiveMinTimestamp: Int
+        let start: Int
+
+        static func parse(_ string: String?) -> Cursor? {
+            guard let string else { return nil }
+            let parts = string.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2,
+                  let ts = Int(parts[0]),
+                  let start = Int(parts[1])
+            else { return nil }
+            return Cursor(effectiveMinTimestamp: ts, start: start)
+        }
+
+        func encoded() -> String {
+            "\(effectiveMinTimestamp):\(start)"
+        }
+    }
+
+    init(networkManager: NetworkManager, baseUrl: String = "https://apilist.tronscanapi.com/api/", apiKey: String?) {
+        self.networkManager = networkManager
+        self.baseUrl = baseUrl
+        self.apiKey = apiKey
+    }
+
+    private func fetch(path: String, parameters: Parameters) async throws -> [String: Any] {
+        var parameters = parameters
+        if let apiKey {
+            parameters["apikey"] = apiKey
+        }
+
+        let json = try await networkManager.fetchJson(
+            url: "\(baseUrl)\(path)",
+            method: .get,
+            parameters: parameters,
+            responseCacherBehavior: .doNotCache
+        )
+
+        guard let map = json as? [String: Any] else {
+            throw RequestError.invalidResponse
+        }
+
+        return map
+    }
+
+    // Builds the next cursor after receiving `count` records from `currentCursor`.
+    // Returns nil if there are no more pages.
+    private func nextCursor(currentCursor: Cursor, receivedCount: Int, lastTimestamp: Int?) -> String? {
+        guard receivedCount >= pageLimit else {
+            return nil // last page
+        }
+
+        let nextStart = currentCursor.start + pageLimit
+
+        // Approaching the 10K offset cap — shift the timestamp window
+        if nextStart >= 9950, let lastTimestamp {
+            return Cursor(effectiveMinTimestamp: lastTimestamp, start: 0).encoded()
+        }
+
+        return Cursor(effectiveMinTimestamp: currentCursor.effectiveMinTimestamp, start: nextStart).encoded()
+    }
+}
+
+// MARK: - IHistoryProvider
+
+extension TronScanProvider: IHistoryProvider {
+    func fetchAccountInfo(address: String) async throws -> AccountInfoResponse {
+        let map = try await fetch(path: "account", parameters: ["address": address])
+
+        let balance = (map["balance"] as? Int) ?? 0
+
+        var trc20 = [Address: BigUInt]()
+        if let tokenBalances = map["trc20token_balances"] as? [[String: Any]] {
+            for token in tokenBalances {
+                guard let contractAddress = token["tokenId"] as? String,
+                      let balanceStr = token["balance"] as? String,
+                      let address = try? Address(address: contractAddress),
+                      let value = BigUInt(balanceStr, radix: 10)
+                else { continue }
+                trc20[address] = value
+            }
+        }
+
+        return AccountInfoResponse(balance: balance, trc20: trc20)
+    }
+
+    func fetchTransactions(address: String, minTimestamp: Int, cursor: String?) async throws -> ([ITransactionResponse], nextCursor: String?) {
+        let resolved = Cursor.parse(cursor) ?? Cursor(effectiveMinTimestamp: minTimestamp, start: 0)
+
+        let map = try await fetch(path: "transaction", parameters: [
+            "address": address,
+            "start_timestamp": resolved.effectiveMinTimestamp,
+            "confirm": 0,
+            "sort": "timestamp",
+            "limit": pageLimit,
+            "start": resolved.start,
+        ])
+
+        guard let data = map["data"] as? [[String: Any]] else {
+            return ([], nil)
+        }
+
+        let transactions: [ITransactionResponse] = data.compactMap { json -> TransactionResponse? in
+            guard let hash = (json["hash"] as? String).flatMap({ $0.hs.hexData }),
+                  let timestamp = json["timestamp"] as? Int,
+                  let block = json["block"] as? Int
+            else { return nil }
+
+            let contractRet = (json["contractRet"] as? String) ?? "SUCCESS"
+            let cost = json["cost"] as? [String: Any]
+            let fee = cost.flatMap { $0["fee"] as? Int } ?? 0
+            let netUsage = cost.flatMap { $0["net_usage"] as? Int } ?? 0
+            let netFee = cost.flatMap { $0["net_fee"] as? Int } ?? 0
+            let energyUsage = cost.flatMap { $0["energy_usage"] as? Int } ?? 0
+            let energyFee = cost.flatMap { $0["energy_fee"] as? Int } ?? 0
+            let energyUsageTotal = cost.flatMap { $0["energy_usage_total"] as? Int } ?? 0
+
+            // Reconstruct raw_data.contract in TronGrid-compatible format so ContractHelper can parse it
+            var contractsMap: [[String: Any]]? = nil
+            if let contractType = json["contractType"] as? Int,
+               let typeString = TronScanProvider.contractTypeName(contractType),
+               let contractData = json["contractData"] as? [String: Any] {
+                contractsMap = [[
+                    "type": typeString,
+                    "parameter": [
+                        "value": contractData,
+                        "type_url": "type.googleapis.com/protocol.\(typeString)",
+                    ],
+                ]]
+            }
+
+            return TransactionResponse(
+                txId: hash,
+                blockTimestamp: timestamp,
+                blockNumber: block,
+                ret: [TransactionResponse.Ret(contractRet: contractRet, fee: fee)],
+                netUsage: netUsage,
+                netFee: netFee,
+                energyUsage: energyUsage,
+                energyFee: energyFee,
+                energyUsageTotal: energyUsageTotal,
+                contractsMap: contractsMap
+            )
+        }
+
+        let lastTimestamp = (data.last?["timestamp"] as? Int)
+        let next = nextCursor(currentCursor: resolved, receivedCount: data.count, lastTimestamp: lastTimestamp)
+        return (transactions, next)
+    }
+
+    func fetchTrc20Transactions(address: String, minTimestamp: Int, cursor: String?) async throws -> ([Trc20TransactionResponse], nextCursor: String?) {
+        let resolved = Cursor.parse(cursor) ?? Cursor(effectiveMinTimestamp: minTimestamp, start: 0)
+
+        let map = try await fetch(path: "token_trc20/transfers", parameters: [
+            "relatedAddress": address,
+            "start_timestamp": resolved.effectiveMinTimestamp,
+            "limit": pageLimit,
+            "start": resolved.start,
+            "direction": 0,
+            "db_version": 1,
+        ])
+
+        guard let transfers = map["token_transfers"] as? [[String: Any]] else {
+            return ([], nil)
+        }
+
+        let transactions: [Trc20TransactionResponse] = transfers.compactMap { json -> Trc20TransactionResponse? in
+            guard let txIdHex = json["transaction_id"] as? String,
+                  let txId = txIdHex.hs.hexData,
+                  let blockTs = json["block_ts"] as? Int,
+                  let fromStr = json["from_address"] as? String,
+                  let toStr = json["to_address"] as? String,
+                  let from = try? Address(address: fromStr),
+                  let to = try? Address(address: toStr),
+                  let contractAddress = json["contract_address"] as? String,
+                  let tokenAddress = try? Address(address: contractAddress),
+                  let quantStr = json["quant"] as? String,
+                  let value = BigUInt(quantStr, radix: 10),
+                  let tokenInfo = json["tokenInfo"] as? [String: Any]
+            else { return nil }
+
+            let symbol = (tokenInfo["tokenAbbr"] as? String) ?? ""
+            let name = (tokenInfo["tokenName"] as? String) ?? ""
+            let decimals = (tokenInfo["tokenDecimal"] as? Int) ?? 0
+
+            return Trc20TransactionResponse(
+                transactionId: txId,
+                blockTimestamp: blockTs,
+                from: from,
+                to: to,
+                type: "Transfer",
+                value: value,
+                tokenInfo: Trc20TransactionResponse.TokenInfo(symbol: symbol, address: tokenAddress, decimals: decimals, name: name)
+            )
+        }
+
+        let lastTimestamp = (transfers.last?["block_ts"] as? Int)
+        let next = nextCursor(currentCursor: resolved, receivedCount: transfers.count, lastTimestamp: lastTimestamp)
+        return (transactions, next)
+    }
+}
+
+extension TronScanProvider {
+    // Maps TronScan integer contractType to the string name used by ContractHelper
+    private static func contractTypeName(_ type: Int) -> String? {
+        switch type {
+        case 1: return "TransferContract"
+        case 2: return "TransferAssetContract"
+        case 4: return "VoteWitnessContract"
+        case 11: return "AssetIssueContract"
+        case 13: return "AccountUpdateContract"
+        case 15: return "FreezeBalanceContract"
+        case 16: return "UnfreezeBalanceContract"
+        case 17: return "WithdrawBalanceContract"
+        case 31: return "TriggerSmartContract"
+        case 41: return "FreezeBalanceV2Contract"
+        case 42: return "UnfreezeBalanceV2Contract"
+        case 44: return "DelegateResourceContract"
+        case 45: return "UnDelegateResourceContract"
+        default: return nil
+        }
+    }
+
+    enum RequestError: Error {
+        case invalidResponse
+    }
+}

--- a/iOS Example/Sources/Adapters/TrxAdapter.swift
+++ b/iOS Example/Sources/Adapters/TrxAdapter.swift
@@ -57,7 +57,7 @@ extension TrxAdapter {
     }
 
     var transactionsSyncState: SyncState {
-        tronKit.syncState
+        tronKit.transactionsSyncState
     }
 
     var balance: Decimal {
@@ -81,7 +81,7 @@ extension TrxAdapter {
     }
 
     var transactionsSyncStatePublisher: AnyPublisher<Void, Never> {
-        tronKit.syncStatePublisher.map { _ in () }.eraseToAnyPublisher()
+        tronKit.transactionsSyncStatePublisher.map { _ in () }.eraseToAnyPublisher()
     }
 
     var balancePublisher: AnyPublisher<Void, Never> {
@@ -93,7 +93,7 @@ extension TrxAdapter {
     }
 
     func transactions(from hash: Data?, limit: Int?) -> [TransactionRecord] {
-        tronKit.transactions(tagQueries: [], fromHash: hash, limit: limit).compactMap { transactionRecord(fullTransaction: $0) }
+        tronKit.transactions(tagQueries: [], hash: hash, descending: true, limit: limit).compactMap { transactionRecord(fullTransaction: $0) }
     }
 
     func transaction(hash _: Data, interTransactionIndex _: Int) -> TransactionRecord? {

--- a/iOS Example/Sources/Configuration.swift
+++ b/iOS Example/Sources/Configuration.swift
@@ -7,6 +7,8 @@ class Configuration {
     let network: Network = .nileTestnet
     let minLogLevel: Logger.Level = .verbose
 
+    let tronGridApiKey: String? = nil  // set your TronGrid API key here
+
     let defaultsWords = "hollow mechanic fortune usual gallery bird test spoil system scissors public trim"
     let defaultsWatchAddress = "TBGMfBsxMZNGtvMJQAP82U3ftW5STiKM1q"
     let defaultSendAddress = "TPewTqxnG9vUFNf2y4g7UgQcAfLcSuJQLH"

--- a/iOS Example/Sources/Core/Manager.swift
+++ b/iOS Example/Sources/Core/Manager.swift
@@ -25,7 +25,8 @@ class Manager {
             address: address,
             network: configuration.network,
             walletId: "walletId",
-            apiKey: nil,
+            rpcSource: .tronGrid(network: configuration.network, apiKey: configuration.tronGridApiKey),
+            transactionSource: .tronGrid(network: configuration.network, apiKey: configuration.tronGridApiKey),
             minLogLevel: configuration.minLogLevel
         )
 


### PR DESCRIPTION
  - Split TronGridProvider into three internal interfaces: IRpcApiProvider (JSON-RPC), INodeApiProvider (FullNode HTTP), IHistoryProvider (history)
  - Add TronScanProvider implementing IHistoryProvider via TronScan API, with timestamp-windowed pagination to work around the 10K offset cap
  - Introduce RpcSource and TransactionSource as public config types, replacing the single apiKey parameter in Kit.instance
  - Split syncState into two independent states: syncState for balance/account sync and transactionsSyncState for transaction history sync
  - Extract TransactionSyncer to own transactionsSyncState; Syncer now handles only balance sync via two paths (history provider or RPC fallback)
  - Add Kit.watchTrc20(contractAddress:) so manually-added TRC20 tokens get their balanceOf called each sync cycle when no history provider is used